### PR TITLE
Support scenario outlines with dynamic names

### DIFF
--- a/src/main/java/com/epam/reportportal/cucumber/AbstractReporter.java
+++ b/src/main/java/com/epam/reportportal/cucumber/AbstractReporter.java
@@ -251,8 +251,8 @@ public abstract class AbstractReporter implements ConcurrentEventListener {
 	 * @param featureContext  current feature context
 	 * @param scenarioContext current scenario context
 	 */
-	protected void beforeScenario(RunningContext.FeatureContext featureContext, RunningContext.ScenarioContext scenarioContext) {
-		String scenarioName = Utils.buildName(scenarioContext.getKeyword(), AbstractReporter.COLON_INFIX, scenarioContext.getName());
+	protected void beforeScenario(RunningContext.FeatureContext featureContext, RunningContext.ScenarioContext scenarioContext, TestCase testCase) {
+		String scenarioName = Utils.buildName(scenarioContext.getKeyword(), AbstractReporter.COLON_INFIX, testCase.getName());
 		RunningContext.RuleContext rule = scenarioContext.getRule();
 		RunningContext.RuleContext currentRule = featureContext.getCurrentRule();
 		if (currentRule == null) {
@@ -709,7 +709,7 @@ public abstract class AbstractReporter implements ConcurrentEventListener {
 			return newScenarioContext;
 		});
 
-		beforeScenario(featureContext, scenarioContext);
+		beforeScenario(featureContext, scenarioContext, testCase);
 	}
 
 	protected void handleTestStepStarted(TestStepStarted event) {

--- a/src/main/java/com/epam/reportportal/cucumber/AbstractReporter.java
+++ b/src/main/java/com/epam/reportportal/cucumber/AbstractReporter.java
@@ -251,8 +251,8 @@ public abstract class AbstractReporter implements ConcurrentEventListener {
 	 * @param featureContext  current feature context
 	 * @param scenarioContext current scenario context
 	 */
-	protected void beforeScenario(RunningContext.FeatureContext featureContext, RunningContext.ScenarioContext scenarioContext, TestCase testCase) {
-		String scenarioName = Utils.buildName(scenarioContext.getKeyword(), AbstractReporter.COLON_INFIX, testCase.getName());
+	protected void beforeScenario(RunningContext.FeatureContext featureContext, RunningContext.ScenarioContext scenarioContext) {
+		String scenarioName = Utils.buildName(scenarioContext.getKeyword(), AbstractReporter.COLON_INFIX, scenarioContext.getTestCase().getName());
 		RunningContext.RuleContext rule = scenarioContext.getRule();
 		RunningContext.RuleContext currentRule = featureContext.getCurrentRule();
 		if (currentRule == null) {
@@ -709,7 +709,7 @@ public abstract class AbstractReporter implements ConcurrentEventListener {
 			return newScenarioContext;
 		});
 
-		beforeScenario(featureContext, scenarioContext, testCase);
+		beforeScenario(featureContext, scenarioContext);
 	}
 
 	protected void handleTestStepStarted(TestStepStarted event) {

--- a/src/test/java/com/epam/reportportal/cucumber/ScenarioOutlineStepReporterTest.java
+++ b/src/test/java/com/epam/reportportal/cucumber/ScenarioOutlineStepReporterTest.java
@@ -40,6 +40,7 @@ import java.util.stream.Stream;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasItems;
 import static org.mockito.Mockito.*;
 
 /**
@@ -51,6 +52,13 @@ public class ScenarioOutlineStepReporterTest {
 			"com.epam.reportportal.cucumber.integration.feature" }, plugin = { "pretty",
 			"com.epam.reportportal.cucumber.integration.TestStepReporter" })
 	public static class RunOutlineParametersTestStepReporter extends AbstractTestNGCucumberTests {
+
+	}
+
+	@CucumberOptions(features = "src/test/resources/features/DynamicScenarioOutlineTitles.feature", glue = {
+			"com.epam.reportportal.cucumber.integration.feature" }, plugin = { "pretty",
+			"com.epam.reportportal.cucumber.integration.TestStepReporter" })
+	public static class RunDynamicScenarioOutlineTitlesTestStepReporter extends AbstractTestNGCucumberTests {
 
 	}
 
@@ -85,5 +93,22 @@ public class ScenarioOutlineStepReporterTest {
 		List<String> items = captor.getAllValues().stream().map(StartTestItemRQ::getName).collect(Collectors.toList());
 
 		assertThat(items, equalTo(Collections.nCopies(3, "Scenario Outline: Test with different parameters")));
+	}
+
+	@Test
+	public void verify_dynamic_scenario_outline_titles() {
+		TestUtils.runTests(RunDynamicScenarioOutlineTitlesTestStepReporter.class);
+
+		verify(client, times(1)).startTestItem(any());
+		ArgumentCaptor<StartTestItemRQ> captor = ArgumentCaptor.forClass(StartTestItemRQ.class);
+		verify(client, times(3)).startTestItem(same(suiteId), captor.capture());
+
+		List<String> items = captor.getAllValues().stream().map(StartTestItemRQ::getName).collect(Collectors.toList());
+
+		assertThat(items, hasItems(
+				"Scenario Outline: Test with the parameter \"first\"",
+				"Scenario Outline: Test with the parameter \"second\"",
+				"Scenario Outline: Test with the parameter \"third\""
+		));
 	}
 }

--- a/src/test/java/com/epam/reportportal/cucumber/ScenarioOutlineStepReporterTest.java
+++ b/src/test/java/com/epam/reportportal/cucumber/ScenarioOutlineStepReporterTest.java
@@ -55,7 +55,7 @@ public class ScenarioOutlineStepReporterTest {
 
 	}
 
-	@CucumberOptions(features = "src/test/resources/features/DynamicScenarioOutlineTitles.feature", glue = {
+	@CucumberOptions(features = "src/test/resources/features/DynamicScenarioOutlineNames.feature", glue = {
 			"com.epam.reportportal.cucumber.integration.feature" }, plugin = { "pretty",
 			"com.epam.reportportal.cucumber.integration.TestStepReporter" })
 	public static class RunDynamicScenarioOutlineTitlesTestStepReporter extends AbstractTestNGCucumberTests {
@@ -96,7 +96,7 @@ public class ScenarioOutlineStepReporterTest {
 	}
 
 	@Test
-	public void verify_dynamic_scenario_outline_titles() {
+	public void verify_dynamic_scenario_outline_names() {
 		TestUtils.runTests(RunDynamicScenarioOutlineTitlesTestStepReporter.class);
 
 		verify(client, times(1)).startTestItem(any());

--- a/src/test/resources/features/DynamicScenarioOutlineNames.feature
+++ b/src/test/resources/features/DynamicScenarioOutlineNames.feature
@@ -1,4 +1,4 @@
-Feature: Dynamic scenario outline titles
+Feature: Dynamic scenario outline names
 
   Scenario Outline: Test with the parameter <str>
     Given It is test with parameters

--- a/src/test/resources/features/DynamicScenarioOutlineTitles.feature
+++ b/src/test/resources/features/DynamicScenarioOutlineTitles.feature
@@ -1,0 +1,12 @@
+Feature: Dynamic scenario outline titles
+
+  Scenario Outline: Test with the parameter <str>
+    Given It is test with parameters
+    When I have parameter <str>
+    Then I emit number <parameters> on level info
+
+    Examples:
+      | str      | parameters |
+      | "first"  | 123        |
+      | "second" | 12345      |
+      | "third"  | 12345678   |


### PR DESCRIPTION
As reported in issue #20, the ReportPortal agent for Cucumber JVM 6 does not currently support scenario outlines with dynamic names, while Cucumber JVM 6 does so. As a consequence, the ReportPortal does not conveniently report test results from scenario outlines with in-name parameters.

This merge request resolves #20 by ensuring that test names are generated on the basis of Cucumber test case names (which vary per test) rather than using the names of Cucumber scenarios (which are fixed per scenario outline). This merge request also supplies a test for this (very small) change/feature.

Thanks in advance for taking issue #20 and this pull request into consideration.

Credits go to @dlitmano for discovering the currently posted solution.