### PR TITLE
Release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 ## [Unreleased]
+### Changed
+- Client version updated on [5.3.17](https://github.com/reportportal/client-java/releases/tag/5.3.17), by @HardNorth
 
 ## [5.4.3]
 ### Changed

--- a/build.gradle
+++ b/build.gradle
@@ -39,7 +39,7 @@ repositories {
 }
 
 dependencies {
-    api 'com.epam.reportportal:client-java:5.3.16'
+    api 'com.epam.reportportal:client-java:5.3.17'
 
     implementation "io.cucumber:cucumber-gherkin:${project.cucumber_version}"
     implementation 'org.slf4j:slf4j-api:2.0.7'


### PR DESCRIPTION
Keep agent-java-test-utils at latest (0.0.13). Client version update noted under Unreleased by @HardNorth.